### PR TITLE
Exclude preferences.arc instead of .arc-env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /node_modules/
 /public/build/
 
-.arc-env
+preferences.arc
 .DS_Store


### PR DESCRIPTION
As promised in a recent Twitter convo with a member of the Begin team this PR amends the gitignore config to exclude the correct env file. 
Happy to make PRs with a similar update to other examples if that would help 👍